### PR TITLE
update hydrosat-scene schema 0.0.1 to include L1 asset properties

### DIFF
--- a/stac-extensions/hydrosat-scene/0.0.1/schema.json
+++ b/stac-extensions/hydrosat-scene/0.0.1/schema.json
@@ -84,6 +84,21 @@
             "day",
             "night"
           ]
+        },
+        "hydrosat:radiometric_scaling.radiance_to_reflectance_scaling": {
+          "title": "Radiance to Reflectance Scaling",
+          "description": "Scaling factor to convert radiance to reflectance for the asset band.",
+          "type": "number"
+        },
+        "hydrosat:brightness_temperature_coefficients.K1_constant": {
+          "title": "Brightness Temperature K1 Constant",
+          "description": "Thermal calibration K1 constant for converting radiance to brightness temperature.",
+          "type": "number"
+        },
+        "hydrosat:brightness_temperature_coefficients.K2_constant": {
+          "title": "Brightness Temperature K2 Constant",
+          "description": "Thermal calibration K2 constant for converting radiance to brightness temperature.",
+          "type": "number"
         }
       },
       "patternProperties": {


### PR DESCRIPTION
This PR updates the `hydrosat-scene` STAC extension schema (v0.0.1) to support additional radiometric/thermal calibration metadata intended for L1 assets.

**Changes:**
- Added `hydrosat:radiometric_scaling.radiance_to_reflectance_scaling` numeric field.
- Added `hydrosat:brightness_temperature_coefficients.K1_constant` / `K2_constant` numeric fields.
- Extended the `definitions.fields` schema so these properties are validated wherever `fields` is referenced.